### PR TITLE
Use transcript prompt file for summarization

### DIFF
--- a/WatchLater/src/services/summarizer.ts
+++ b/WatchLater/src/services/summarizer.ts
@@ -1,13 +1,19 @@
 import { tryGetTranscript, extractVideoId } from "./youtube";
 import { callGeminiAPI } from "./gemini";
+// Import the transcript processing prompt as raw text. Vite's `?raw` query
+// allows bundling the markdown file contents directly as a string.
+import transcriptPrompt from "../../prompts/Youtube transcripts.md?raw";
 
 export async function summarize(url: string): Promise<string> {
   const id = extractVideoId(url);
   const transcript = await tryGetTranscript(id);
 
+  // Start with the base prompt from the markdown file.
+  const base = transcriptPrompt.trim();
+
   const prompt = transcript
-    ? `### TRANSCRIPT\n${transcript}\n\n### TASK\nSummarize the transcript in markdown.`
-    : `Summarize the YouTube video at ${url} in markdown as if you had its transcript.`;
+    ? `${base}\n\n### TRANSCRIPT\n${transcript}`
+    : `${base}\n\nSummarize the YouTube video at ${url} in markdown as if you had its transcript.`;
 
   const resp = await callGeminiAPI(prompt);
   return resp.text;


### PR DESCRIPTION
## Summary
- load the YouTube transcript processing prompt as raw text in the summarizer
- append the fetched transcript to this prompt before calling Gemini

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68616e1059ec832a8d0f5170bda4e810