### PR TITLE
fix: close batch import modal after queueing

### DIFF
--- a/WatchLater/server/markdown-to-html.js
+++ b/WatchLater/server/markdown-to-html.js
@@ -49,6 +49,13 @@ const BASE_STYLES = `
     opacity: 0.95;
   }
 
+  .header-subtitle {
+    font-size: 16px;
+    font-weight: 500;
+    margin: 0;
+    opacity: 0.9;
+  }
+
   a {
     color: #3c55f3;
     text-decoration: none;
@@ -274,7 +281,8 @@ function formatTimestamp(timestamp) {
  *  videoId?: string,
  *  generatedAt?: string,
  *  wordCount?: number,
- *  summaryLength?: number
+ *  summaryLength?: number,
+ *  author?: string
  * }} [metadata]
  * @returns {string}
  */
@@ -289,7 +297,8 @@ export function renderSummaryMarkdown(markdownContent, metadata = {}) {
     title = 'Video Summary',
     videoId = 'unknown',
     generatedAt = '',
-    summaryLength
+    summaryLength,
+    author = ''
   } = metadata;
 
   const formattedTimestamp = formatTimestamp(generatedAt);
@@ -311,6 +320,7 @@ export function renderSummaryMarkdown(markdownContent, metadata = {}) {
           <span>PDF Export</span>
         </nav>
         <h1>${escapeHtml(title)}</h1>
+        ${author ? `<p class="header-subtitle">By ${escapeHtml(author)}</p>` : ''}
         <div class="meta-grid">
           <div class="meta-item">
             <span>Video ID</span>

--- a/WatchLater/src/App.css
+++ b/WatchLater/src/App.css
@@ -797,6 +797,32 @@
   color: var(--color-text-primary);
 }
 
+.summary-article {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.summary-article__header {
+  display: grid;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.summary-article__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 2rem;
+  line-height: 1.2;
+}
+
+.summary-article__creator {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
 .summary-markdown h1,
 .summary-markdown h2,
 .summary-markdown h3 {
@@ -897,6 +923,11 @@
 
 .history-item-title {
   font-weight: 600;
+}
+
+.history-item-author {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
 }
 
 .history-item-meta {

--- a/WatchLater/src/components/BatchImportModal.tsx
+++ b/WatchLater/src/components/BatchImportModal.tsx
@@ -217,13 +217,14 @@ const BatchImportModal: React.FC<BatchImportModalProps> = ({
 
       try {
         await Promise.resolve(onSubmit(validRequests));
+        onClose();
       } catch (error) {
         const message =
           error instanceof Error ? error.message : 'Unable to queue imports. Please retry.';
         setSubmissionError(message);
       }
     },
-    [importDisabled, onSubmit, validRequests]
+    [importDisabled, onClose, onSubmit, validRequests]
   );
 
   const handleCancel = useCallback(() => {

--- a/WatchLater/tests/api-model-selection.test.ts
+++ b/WatchLater/tests/api-model-selection.test.ts
@@ -59,13 +59,14 @@ describe('model-aware API surfaces', () => {
 
     globalThis.fetch = mockFetch;
 
-    const result = await saveSummaryToServer('video123', 'Hello world', 'My Title', 'model-b');
+    const result = await saveSummaryToServer('video123', 'Hello world', 'My Title', 'model-b', 'Creator Name');
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [, requestInit] = mockFetch.mock.calls[0];
     expect(requestInit).toBeDefined();
     const body = JSON.parse((requestInit as RequestInit).body as string);
     expect(body.modelId).toBe('model-b');
+    expect(body.author).toBe('Creator Name');
     expect(result.modelId).toBe('model-b');
   });
 


### PR DESCRIPTION
## Summary
- include author metadata when saving summary files and expose it via the summaries APIs
- render creator names in the saved summaries sidebar and PDF export header
- propagate author fields through the client API utilities and update related tests
- format summary exports and in-app rendering with video title and creator bylines
- ensure the batch import dialog closes automatically once videos are queued

## Testing
- npm run lint
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d485563cec8322bcb500777ff97e37